### PR TITLE
Adding UriAugmenterService in order to augment Url generation.

### DIFF
--- a/Geta.Optimizely.Sitemaps.sln
+++ b/Geta.Optimizely.Sitemaps.sln
@@ -7,9 +7,35 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sandbox", "Sandbox", "{9003
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Geta.Optimizely.Sitemaps", "src\Geta.Optimizely.Sitemaps\Geta.Optimizely.Sitemaps.csproj", "{A56D25DD-73FB-4754-B054-C5CD9B52804F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Geta.Optimizely.Sitemaps.Commerce", "src\Geta.Optimizely.Sitemaps.Commerce\Geta.Optimizely.Sitemaps.Commerce.csproj", "{39B5430D-35AF-4413-980B-1CE51B367DC7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Geta.Optimizely.Sitemaps.Commerce", "src\Geta.Optimizely.Sitemaps.Commerce\Geta.Optimizely.Sitemaps.Commerce.csproj", "{39B5430D-35AF-4413-980B-1CE51B367DC7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Foundation", "sandbox\Foundation\src\Foundation\Foundation.csproj", "{82A14BA5-4A85-4DC3-833E-37EBC47BB891}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Foundation", "sandbox\Foundation\src\Foundation\Foundation.csproj", "{82A14BA5-4A85-4DC3-833E-37EBC47BB891}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionItems", "{A71AFC18-7B1C-422E-B556-A1F124C79E34}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		CHANGELOG.md = CHANGELOG.md
+		CONTRIBUTING.md = CONTRIBUTING.md
+		LICENSE.md = LICENSE.md
+		NuGet.config = NuGet.config
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{FEDCD604-4393-4662-BD63-0469772CF527}"
+	ProjectSection(SolutionItems) = preProject
+		docs\editor-guide.md = docs\editor-guide.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "images", "images", "{FE02F591-778A-4883-BA52-DA2B6B93D483}"
+	ProjectSection(SolutionItems) = preProject
+		docs\images\docker-debugging-output.PNG = docs\images\docker-debugging-output.PNG
+		docs\images\docker-output.PNG = docs\images\docker-output.PNG
+		docs\images\sitemap-property.PNG = docs\images\sitemap-property.PNG
+		docs\images\sitemap-scheduled-job.PNG = docs\images\sitemap-scheduled-job.PNG
+		docs\images\SitemapAdd.png = docs\images\SitemapAdd.png
+		docs\images\SitemapAddMultiSite.png = docs\images\SitemapAddMultiSite.png
+		docs\images\SitemapConfigure.png = docs\images\SitemapConfigure.png
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -35,6 +61,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{82A14BA5-4A85-4DC3-833E-37EBC47BB891} = {9003527C-5B4F-48DB-8946-E6E6773B2EDF}
+		{FE02F591-778A-4883-BA52-DA2B6B93D483} = {FEDCD604-4393-4662-BD63-0469772CF527}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B7726B88-56CE-4817-8E7C-0EC0B74F1431}

--- a/Geta.Optimizely.Sitemaps.sln
+++ b/Geta.Optimizely.Sitemaps.sln
@@ -11,22 +11,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Geta.Optimizely.Sitemaps.Co
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Foundation", "sandbox\Foundation\src\Foundation\Foundation.csproj", "{82A14BA5-4A85-4DC3-833E-37EBC47BB891}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{FEDCD604-4393-4662-BD63-0469772CF527}"
-	ProjectSection(SolutionItems) = preProject
-		docs\editor-guide.md = docs\editor-guide.md
-	EndProjectSection
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "images", "images", "{FE02F591-778A-4883-BA52-DA2B6B93D483}"
-	ProjectSection(SolutionItems) = preProject
-		docs\images\docker-debugging-output.PNG = docs\images\docker-debugging-output.PNG
-		docs\images\docker-output.PNG = docs\images\docker-output.PNG
-		docs\images\sitemap-property.PNG = docs\images\sitemap-property.PNG
-		docs\images\sitemap-scheduled-job.PNG = docs\images\sitemap-scheduled-job.PNG
-		docs\images\SitemapAdd.png = docs\images\SitemapAdd.png
-		docs\images\SitemapAddMultiSite.png = docs\images\SitemapAddMultiSite.png
-		docs\images\SitemapConfigure.png = docs\images\SitemapConfigure.png
-	EndProjectSection
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,7 +35,6 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{82A14BA5-4A85-4DC3-833E-37EBC47BB891} = {9003527C-5B4F-48DB-8946-E6E6773B2EDF}
-		{FE02F591-778A-4883-BA52-DA2B6B93D483} = {FEDCD604-4393-4662-BD63-0469772CF527}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B7726B88-56CE-4817-8E7C-0EC0B74F1431}

--- a/Geta.Optimizely.Sitemaps.sln
+++ b/Geta.Optimizely.Sitemaps.sln
@@ -11,16 +11,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Geta.Optimizely.Sitemaps.Co
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Foundation", "sandbox\Foundation\src\Foundation\Foundation.csproj", "{82A14BA5-4A85-4DC3-833E-37EBC47BB891}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionItems", "{A71AFC18-7B1C-422E-B556-A1F124C79E34}"
-	ProjectSection(SolutionItems) = preProject
-		.gitignore = .gitignore
-		CHANGELOG.md = CHANGELOG.md
-		CONTRIBUTING.md = CONTRIBUTING.md
-		LICENSE.md = LICENSE.md
-		NuGet.config = NuGet.config
-		README.md = README.md
-	EndProjectSection
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{FEDCD604-4393-4662-BD63-0469772CF527}"
 	ProjectSection(SolutionItems) = preProject
 		docs\editor-guide.md = docs\editor-guide.md

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This tool allows you to generate xml sitemaps for search engines to better index
 - ability to include pages that are in a different branch than the one of the start page
 - ability to generate sitemaps for mobile pages
 - it also supports multi-site and multi-language environments
+- ability to augment url generation for parameterized pages using QueryStrings.
 
 See the [editor guide](docs/editor-guide.md) for more information.
 
@@ -57,6 +58,13 @@ services.AddSitemaps(x =>
   x.EnableRealtimeCaching = true;
   x.EnableRealtimeSitemap = false;
 }, p => p.RequireRole(Roles.Administrators));
+```
+
+In order to augment Urls you must remove the default IUriAugmenterService and implement your own:
+```csharp
+// Swap out the NullUriAugmenterService so we can augment Urls within the Sitemap.
+services.RemoveAll<IUriAugmenterService>();
+services.AddSingleton<IUriAugmenterService, SitemapUriParameterAugmenterService>();
 ```
 
 And for the Commerce support add a call to:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This tool allows you to generate xml sitemaps for search engines to better index
 - ability to include pages that are in a different branch than the one of the start page
 - ability to generate sitemaps for mobile pages
 - it also supports multi-site and multi-language environments
-- ability to augment url generation for parameterized pages using QueryStrings.
+- ability to augment URL generation for parameterized pages using QueryStrings
 
 See the [editor guide](docs/editor-guide.md) for more information.
 
@@ -60,11 +60,13 @@ services.AddSitemaps(x =>
 }, p => p.RequireRole(Roles.Administrators));
 ```
 
-In order to augment Urls you must remove the default IUriAugmenterService and implement your own:
+In order to augment Urls for the PersonListPage with the corresponding querystring parameters for said page, please review the (SitemapUriParameterAugmenterService class)[Sandbox/Foundation/Infrastructure/Cms/Services/SitemapUriParameterAugmenterService.cs] within the Foundation project:
+
 ```csharp
-// Swap out the NullUriAugmenterService so we can augment Urls within the Sitemap.
-services.RemoveAll<IUriAugmenterService>();
-services.AddSingleton<IUriAugmenterService, SitemapUriParameterAugmenterService>();
+services.AddSitemaps(options =>
+{
+    options.UriAugmenterServiceImplementationFactory = sp => sp.GetInstance<SitemapUriParameterAugmenterService>();
+});
 ```
 
 And for the Commerce support add a call to:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This tool allows you to generate xml sitemaps for search engines to better index
 - ability to include pages that are in a different branch than the one of the start page
 - ability to generate sitemaps for mobile pages
 - it also supports multi-site and multi-language environments
-- ability to augment URL generation for parameterized pages using QueryStrings
+- ability to augment URL generation
 
 See the [editor guide](docs/editor-guide.md) for more information.
 
@@ -60,19 +60,22 @@ services.AddSitemaps(x =>
 }, p => p.RequireRole(Roles.Administrators));
 ```
 
-In order to augment Urls for the PersonListPage with the corresponding querystring parameters for said page, please review the [SitemapUriParameterAugmenterService class](sandbox/Foundation/src/Foundation/Infrastructure/Cms/Services/SitemapUriParameterAugmenterService.cs) within the Foundation project:
+And for the Commerce support add a call to:
+```csharp
+services.AddSitemapsCommerce();
+```
+
+In order to augment Urls for a given set of content one must prepare to build a service that identifies content to be augmented
+and yields augmented Uris from IUriAugmenterService.GetAugmentUris(IContent content, CurrentLanguageContent languageContentInfo, Uri fullUri) method.
+
+1. [Create a service that implements IUriAugmenterService yielding multiple Uris per single input content/language/Uri.](sandbox/Foundation/src/Foundation/Infrastructure/Cms/Services/SitemapUriParameterAugmenterService.cs).
+2. Ensure the services is set, overring the default service, within the optionsAction of AddSitemaps. For example:
 
 ```csharp
 services.AddSitemaps(options =>
 {
     options.SetAugmenterService<SitemapUriParameterAugmenterService>();
 });
-```
-
-
-And for the Commerce support add a call to:
-```csharp
-services.AddSitemapsCommerce();
 ```
 
 It is also possible to configure the application in `appsettings.json` file. A configuration from the `appsettings.json` will override configuration configured in Startup. Below is an `appsettings.json` configuration example.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ services.AddSitemaps(x =>
 }, p => p.RequireRole(Roles.Administrators));
 ```
 
-In order to augment Urls for the PersonListPage with the corresponding querystring parameters for said page, please review the (SitemapUriParameterAugmenterService class)[Sandbox/Foundation/Infrastructure/Cms/Services/SitemapUriParameterAugmenterService.cs] within the Foundation project:
+In order to augment Urls for the PersonListPage with the corresponding querystring parameters for said page, please review the [SitemapUriParameterAugmenterService class](Sandbox/Foundation/Infrastructure/Cms/Services/SitemapUriParameterAugmenterService.cs) within the Foundation project:
 
 ```csharp
 services.AddSitemaps(options =>

--- a/README.md
+++ b/README.md
@@ -63,17 +63,10 @@ services.AddSitemaps(x =>
 In order to augment Urls for the PersonListPage with the corresponding querystring parameters for said page, please review the [SitemapUriParameterAugmenterService class](sandbox/Foundation/src/Foundation/Infrastructure/Cms/Services/SitemapUriParameterAugmenterService.cs) within the Foundation project:
 
 ```csharp
-services.AddSitemaps(uriAugmenterService: sp => sp.GetInstance<SitemapUriParameterAugmenterService>());
-```
-
-Or, alternatively:
-```csharp
-services.AddSitemaps(x =>
+services.AddSitemaps(options =>
 {
-  x.EnableLanguageDropDownInAdmin = false;
-  x.EnableRealtimeCaching = true;
-  x.EnableRealtimeSitemap = false;
-}, sp => sp.GetInstance<SitemapUriParameterAugmenterService>());
+    options.SetAugmenterService<SitemapUriParameterAugmenterService>();
+});
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,19 @@ services.AddSitemaps(x =>
 In order to augment Urls for the PersonListPage with the corresponding querystring parameters for said page, please review the [SitemapUriParameterAugmenterService class](sandbox/Foundation/src/Foundation/Infrastructure/Cms/Services/SitemapUriParameterAugmenterService.cs) within the Foundation project:
 
 ```csharp
-services.AddSitemaps(options =>
-{
-    options.UriAugmenterServiceImplementationFactory = sp => sp.GetInstance<SitemapUriParameterAugmenterService>();
-});
+services.AddSitemaps(uriAugmenterService: sp => sp.GetInstance<SitemapUriParameterAugmenterService>());
 ```
+
+Or, alternatively:
+```csharp
+services.AddSitemaps(x =>
+{
+  x.EnableLanguageDropDownInAdmin = false;
+  x.EnableRealtimeCaching = true;
+  x.EnableRealtimeSitemap = false;
+}, sp => sp.GetInstance<SitemapUriParameterAugmenterService>());
+```
+
 
 And for the Commerce support add a call to:
 ```csharp

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ services.AddSitemaps(x =>
 }, p => p.RequireRole(Roles.Administrators));
 ```
 
-In order to augment Urls for the PersonListPage with the corresponding querystring parameters for said page, please review the [SitemapUriParameterAugmenterService class](Sandbox/Foundation/Infrastructure/Cms/Services/SitemapUriParameterAugmenterService.cs) within the Foundation project:
+In order to augment Urls for the PersonListPage with the corresponding querystring parameters for said page, please review the [SitemapUriParameterAugmenterService class](sandbox/Foundation/src/Foundation/Infrastructure/Cms/Services/SitemapUriParameterAugmenterService.cs) within the Foundation project:
 
 ```csharp
 services.AddSitemaps(options =>

--- a/sandbox/Foundation/src/Foundation/Infrastructure/Cms/Services/SitemapUriParameterAugmenterService.cs
+++ b/sandbox/Foundation/src/Foundation/Infrastructure/Cms/Services/SitemapUriParameterAugmenterService.cs
@@ -26,7 +26,7 @@ namespace Foundation.Infrastructure.Cms.Services
 
         public IEnumerable<Uri> GetAugmentUri(IContent content, CurrentLanguageContent languageContentInfo, Uri fullUri)
         {
-            if (((PageData)content).PageTypeName == "PersonListPage")
+            if (((PageData)content).PageTypeName == nameof(Features.People.PersonListPage))
             {
                 var fullUriString = fullUri.ToString();
 

--- a/sandbox/Foundation/src/Foundation/Infrastructure/Cms/Services/SitemapUriParameterAugmenterService.cs
+++ b/sandbox/Foundation/src/Foundation/Infrastructure/Cms/Services/SitemapUriParameterAugmenterService.cs
@@ -26,25 +26,28 @@ namespace Foundation.Infrastructure.Cms.Services
 
         public IEnumerable<Uri> GetAugmentUri(IContent content, CurrentLanguageContent languageContentInfo, Uri fullUri)
         {
-            if (((PageData)content).PageTypeName == nameof(Features.People.PersonListPage))
+            if (content is PageData pageContent)
             {
-                var fullUriString = fullUri.ToString();
-
-                var personPageType = _contentTypeRepository.Load<PersonPage>();
-                var usages = _contentModelUsage.ListContentOfContentType(personPageType).Select(c => _contentRepository.Get<PersonPage>(c.ContentLink));
-                // Group all of the results by the querystring parameters that drive the page.
-                var nameSectorLocations = usages.GroupBy(k => new { k.Name, k.Sector, k.Location });
-
-                // Enumerate the total set of expected name/sectors/locations in ordr for them to be indexed.
-                foreach (var nameSectorLocation in nameSectorLocations)
+                if (pageContent.PageTypeName == nameof(Features.People.PersonListPage))
                 {
-                    var augmentedUri = new Uri($"{fullUriString}?name={nameSectorLocation.Key.Name}&sector={nameSectorLocation.Key.Sector}&location={nameSectorLocation.Key.Location}");
-                    yield return augmentedUri;
+                    var fullUriString = fullUri.ToString();
+
+                    var personPageType = _contentTypeRepository.Load<PersonPage>();
+                    var usages = _contentModelUsage.ListContentOfContentType(personPageType).Select(c => _contentRepository.Get<PersonPage>(c.ContentLink));
+                    // Group all of the results by the querystring parameters that drive the page.
+                    var nameSectorLocations = usages.GroupBy(k => new { k.Name, k.Sector, k.Location });
+
+                    // Enumerate the total set of expected name/sectors/locations in ordr for them to be indexed.
+                    foreach (var nameSectorLocation in nameSectorLocations)
+                    {
+                        var augmentedUri = new Uri($"{fullUriString}?name={nameSectorLocation.Key.Name}&sector={nameSectorLocation.Key.Sector}&location={nameSectorLocation.Key.Location}");
+                        yield return augmentedUri;
+                    }
                 }
-            }
-            else
-            {
-                yield return fullUri;
+                else
+                {
+                    yield return fullUri;
+                }
             }
         }
     }

--- a/sandbox/Foundation/src/Foundation/Infrastructure/Cms/Services/SitemapUriParameterAugmenterService.cs
+++ b/sandbox/Foundation/src/Foundation/Infrastructure/Cms/Services/SitemapUriParameterAugmenterService.cs
@@ -1,0 +1,51 @@
+﻿using EPiServer;
+using EPiServer.Core;
+using EPiServer.DataAbstraction;
+using Foundation.Features.People.PersonItemPage;
+using Geta.Optimizely.Sitemaps;
+using Geta.Optimizely.Sitemaps.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Foundation.Infrastructure.Cms.Services
+{
+    public class SitemapUriParameterAugmenterService : IUriAugmenterService
+    {
+        private readonly IContentTypeRepository _contentTypeRepository;
+        private readonly IContentModelUsage _contentModelUsage;
+        private readonly IContentRepository _contentRepository;
+
+        public SitemapUriParameterAugmenterService(IContentTypeRepository contentTypeRepository, IContentModelUsage contentModelUsage, IContentRepository contentRepository)
+        {
+            _contentTypeRepository = contentTypeRepository;
+            _contentModelUsage = contentModelUsage;
+            _contentRepository = contentRepository;
+        }
+
+        public IEnumerable<Uri> GetAugmentUri(IContent content, CurrentLanguageContent languageContentInfo, Uri fullUri)
+        {
+            if (((PageData)content).PageTypeName == "PersonListPage")
+            {
+                var fullUriString = fullUri.ToString();
+
+                var personPageType = _contentTypeRepository.Load<PersonPage>();
+                var usages = _contentModelUsage.ListContentOfContentType(personPageType).Select(c => _contentRepository.Get<PersonPage>(c.ContentLink));
+                // Group all of the results by the querystring parameters that drive the page.
+                var nameSectorLocations = usages.GroupBy(k => new { k.Name, k.Sector, k.Location });
+
+                // Enumerate the total set of expected name/sectors/locations in ordr for them to be indexed.
+                foreach (var nameSectorLocation in nameSectorLocations)
+                {
+                    var augmentedUri = new Uri($"{fullUriString}?name={nameSectorLocation.Key.Name}&sector={nameSectorLocation.Key.Sector}&location={nameSectorLocation.Key.Location}");
+                    yield return augmentedUri;
+                }
+            }
+            else
+            {
+                yield return fullUri;
+            }
+        }
+    }
+}

--- a/sandbox/Foundation/src/Foundation/Infrastructure/Cms/Services/SitemapUriParameterAugmenterService.cs
+++ b/sandbox/Foundation/src/Foundation/Infrastructure/Cms/Services/SitemapUriParameterAugmenterService.cs
@@ -24,7 +24,7 @@ namespace Foundation.Infrastructure.Cms.Services
             _contentRepository = contentRepository;
         }
 
-        public IEnumerable<Uri> GetAugmentUri(IContent content, CurrentLanguageContent languageContentInfo, Uri fullUri)
+        public IEnumerable<Uri> GetAugmentUris(IContent content, CurrentLanguageContent languageContentInfo, Uri fullUri)
         {
             if (content is PageData pageContent)
             {

--- a/sandbox/Foundation/src/Foundation/Startup.cs
+++ b/sandbox/Foundation/src/Foundation/Startup.cs
@@ -97,11 +97,8 @@ namespace Foundation
             services.AddTinyMceConfiguration();
 
             services.AddSingleton<SitemapUriParameterAugmenterService>();
-            services.AddSitemaps(options =>
-            {
-                // Implement the UriAugmenterServiceImplementationFactory in order to enumerate the PersonalListPage querystring parameters.
-                options.UriAugmenterServiceImplementationFactory = sp => sp.GetInstance<SitemapUriParameterAugmenterService>();
-            });
+            // Implement the UriAugmenterServiceImplementationFactory in order to enumerate the PersonalListPage querystring parameters.
+            services.AddSitemaps(uriAugmenterService: sp => sp.GetInstance<SitemapUriParameterAugmenterService>());
             services.AddSitemapsCommerce();
 
             //site specific

--- a/sandbox/Foundation/src/Foundation/Startup.cs
+++ b/sandbox/Foundation/src/Foundation/Startup.cs
@@ -1,9 +1,12 @@
-﻿using EPiServer.Authorization;
+﻿using EPiServer;
+using EPiServer.Authorization;
 using EPiServer.ContentApi.Cms;
 using EPiServer.ContentApi.Cms.Internal;
 using EPiServer.ContentDefinitionsApi;
 using EPiServer.ContentManagementApi;
+using EPiServer.Core;
 using EPiServer.Data;
+using EPiServer.DataAbstraction;
 using EPiServer.Framework.Web.Resources;
 using EPiServer.Labs.ContentManager;
 using EPiServer.OpenIDConnect;
@@ -15,6 +18,7 @@ using Foundation.Features.Checkout.Payments;
 using Foundation.Infrastructure;
 using Foundation.Infrastructure.Cms.Extensions;
 using Foundation.Infrastructure.Cms.ModelBinders;
+using Foundation.Infrastructure.Cms.Services;
 using Foundation.Infrastructure.Cms.Users;
 using Foundation.Infrastructure.Display;
 using Geta.NotFoundHandler.Infrastructure.Configuration;
@@ -22,6 +26,7 @@ using Geta.NotFoundHandler.Infrastructure.Initialization;
 using Geta.NotFoundHandler.Optimizely;
 using Geta.Optimizely.Sitemaps;
 using Geta.Optimizely.Sitemaps.Commerce;
+using Geta.Optimizely.Sitemaps.Services;
 using Jhoose.Security.DependencyInjection;
 using Mediachase.Commerce.Anonymous;
 using Mediachase.Commerce.Orders;
@@ -91,7 +96,12 @@ namespace Foundation
             services.AddDetection();
             services.AddTinyMceConfiguration();
 
-            services.AddSitemaps();
+            services.AddSingleton<SitemapUriParameterAugmenterService>();
+            services.AddSitemaps(options =>
+            {
+                // Implement the UriAugmenterServiceImplementationFactory in order to enumerate the PersonalListPage querystring parameters.
+                options.UriAugmenterServiceImplementationFactory = sp => sp.GetInstance<SitemapUriParameterAugmenterService>();
+            });
             services.AddSitemapsCommerce();
 
             //site specific

--- a/sandbox/Foundation/src/Foundation/Startup.cs
+++ b/sandbox/Foundation/src/Foundation/Startup.cs
@@ -99,7 +99,7 @@ namespace Foundation
             // Implement the UriAugmenterServiceImplementationFactory in order to enumerate the PersonalListPage querystring parameters.
             services.AddSitemaps(options =>
             {
-                options.SetAugmenterService<SitemapUriParameterAugmenterService>(services);
+                options.SetAugmenterService<SitemapUriParameterAugmenterService>();
             });
             services.AddSitemapsCommerce();
 

--- a/sandbox/Foundation/src/Foundation/Startup.cs
+++ b/sandbox/Foundation/src/Foundation/Startup.cs
@@ -96,9 +96,11 @@ namespace Foundation
             services.AddDetection();
             services.AddTinyMceConfiguration();
 
-            services.AddSingleton<SitemapUriParameterAugmenterService>();
             // Implement the UriAugmenterServiceImplementationFactory in order to enumerate the PersonalListPage querystring parameters.
-            services.AddSitemaps(uriAugmenterService: sp => sp.GetInstance<SitemapUriParameterAugmenterService>());
+            services.AddSitemaps(options =>
+            {
+                options.SetAugmenterService<SitemapUriParameterAugmenterService>(services);
+            });
             services.AddSitemapsCommerce();
 
             //site specific

--- a/src/Geta.Optimizely.Sitemaps.Commerce/CommerceAndStandardSitemapXmlGenerator.cs
+++ b/src/Geta.Optimizely.Sitemaps.Commerce/CommerceAndStandardSitemapXmlGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Geta Digital. All rights reserved.
+// Copyright (c) Geta Digital. All rights reserved.
 // Licensed under Apache-2.0. See the LICENSE file in the project root for more information
 
 using System.Collections.Generic;
@@ -10,6 +10,7 @@ using EPiServer.Framework.Cache;
 using EPiServer.Web;
 using EPiServer.Web.Routing;
 using Geta.Optimizely.Sitemaps.Repositories;
+using Geta.Optimizely.Sitemaps.Services;
 using Geta.Optimizely.Sitemaps.Utils;
 using Geta.Optimizely.Sitemaps.XML;
 using Mediachase.Commerce.Catalog;
@@ -33,6 +34,7 @@ namespace Geta.Optimizely.Sitemaps.Commerce
             ILanguageBranchRepository languageBranchRepository,
             ReferenceConverter referenceConverter,
             IContentFilter contentFilter,
+            IUriAugmenterService uriAugmenterService,
             ISynchronizedObjectInstanceCache objectCache,
             IMemoryCache memoryCache,
             ILogger<CommerceAndStandardSitemapXmlGenerator> logger)
@@ -44,6 +46,7 @@ namespace Geta.Optimizely.Sitemaps.Commerce
                 languageBranchRepository,
                 referenceConverter,
                 contentFilter,
+                uriAugmenterService,
                 objectCache,
                 memoryCache,
                 logger)

--- a/src/Geta.Optimizely.Sitemaps.Commerce/CommerceSitemapXmlGenerator.cs
+++ b/src/Geta.Optimizely.Sitemaps.Commerce/CommerceSitemapXmlGenerator.cs
@@ -68,7 +68,7 @@ namespace Geta.Optimizely.Sitemaps.Commerce
                 };
             }
 
-            var descendants = ContentRepository.GetDescendents(rootContentReference).ToList();
+            var descendants = ContentRepository.GetDescendents(rootContentReference);
 
             return GenerateXmlElements(descendants);
         }

--- a/src/Geta.Optimizely.Sitemaps.Commerce/CommerceSitemapXmlGenerator.cs
+++ b/src/Geta.Optimizely.Sitemaps.Commerce/CommerceSitemapXmlGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Geta Digital. All rights reserved.
+// Copyright (c) Geta Digital. All rights reserved.
 // Licensed under Apache-2.0. See the LICENSE file in the project root for more information
 
 using System;
@@ -12,6 +12,7 @@ using EPiServer.Framework.Cache;
 using EPiServer.Web;
 using EPiServer.Web.Routing;
 using Geta.Optimizely.Sitemaps.Repositories;
+using Geta.Optimizely.Sitemaps.Services;
 using Geta.Optimizely.Sitemaps.Utils;
 using Geta.Optimizely.Sitemaps.XML;
 using Mediachase.Commerce.Catalog;
@@ -36,6 +37,7 @@ namespace Geta.Optimizely.Sitemaps.Commerce
             ILanguageBranchRepository languageBranchRepository,
             ReferenceConverter referenceConverter,
             IContentFilter contentFilter,
+            IUriAugmenterService uriAugmenterService,
             ISynchronizedObjectInstanceCache objectCache,
             IMemoryCache memoryCache,
             ILogger<CommerceSitemapXmlGenerator> logger)
@@ -46,6 +48,7 @@ namespace Geta.Optimizely.Sitemaps.Commerce
                 siteDefinitionRepository,
                 languageBranchRepository,
                 contentFilter,
+                uriAugmenterService,
                 objectCache,
                 memoryCache,
                 logger)

--- a/src/Geta.Optimizely.Sitemaps/Configuration/SitemapOptions.cs
+++ b/src/Geta.Optimizely.Sitemaps/Configuration/SitemapOptions.cs
@@ -8,6 +8,5 @@ namespace Geta.Optimizely.Sitemaps.Configuration
         public bool EnableRealtimeSitemap { get; set; } = false;
         public bool EnableRealtimeCaching { get; set; } = true;
         public bool EnableLanguageDropDownInAdmin { get; set; } = false;
-        public Func<IServiceProvider, IUriAugmenterService> UriAugmenterServiceImplementationFactory { get; set; } = null;
     }
 }

--- a/src/Geta.Optimizely.Sitemaps/Configuration/SitemapOptions.cs
+++ b/src/Geta.Optimizely.Sitemaps/Configuration/SitemapOptions.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Linq;
 using Geta.Optimizely.Sitemaps.Services;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Geta.Optimizely.Sitemaps.Configuration
 {
@@ -11,7 +9,7 @@ namespace Geta.Optimizely.Sitemaps.Configuration
         public bool EnableRealtimeCaching { get; set; } = true;
         public bool EnableLanguageDropDownInAdmin { get; set; } = false;
 
-        public Type UriAugmenterService { get; set; }
+        public Type UriAugmenterService { get; set; } = typeof(DefaultUriAugmenterService);
 
         public void SetAugmenterService<T>() where T : class, IUriAugmenterService
         {

--- a/src/Geta.Optimizely.Sitemaps/Configuration/SitemapOptions.cs
+++ b/src/Geta.Optimizely.Sitemaps/Configuration/SitemapOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Geta.Optimizely.Sitemaps.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,13 +11,11 @@ namespace Geta.Optimizely.Sitemaps.Configuration
         public bool EnableRealtimeCaching { get; set; } = true;
         public bool EnableLanguageDropDownInAdmin { get; set; } = false;
 
-        public void SetAugmenterService<T>(IServiceCollection services) where T : class, IUriAugmenterService
+        public Type UriAugmenterService { get; set; }
+
+        public void SetAugmenterService<T>() where T : class, IUriAugmenterService
         {
-            var augmenterService = services.First(sd => sd.ServiceType == typeof(IUriAugmenterService));
-            // Remove the existing service in order to replace it.
-            services.Remove(augmenterService);
-            
-            services.AddSingleton<IUriAugmenterService, T>();
+            UriAugmenterService = typeof(T);
         }
     }
 }

--- a/src/Geta.Optimizely.Sitemaps/Configuration/SitemapOptions.cs
+++ b/src/Geta.Optimizely.Sitemaps/Configuration/SitemapOptions.cs
@@ -1,9 +1,13 @@
-﻿namespace Geta.Optimizely.Sitemaps.Configuration
+using System;
+using Geta.Optimizely.Sitemaps.Services;
+
+namespace Geta.Optimizely.Sitemaps.Configuration
 {
     public class SitemapOptions
     {
         public bool EnableRealtimeSitemap { get; set; } = false;
         public bool EnableRealtimeCaching { get; set; } = true;
         public bool EnableLanguageDropDownInAdmin { get; set; } = false;
+        public Func<IServiceProvider, IUriAugmenterService> UriAugmenterServiceImplementationFactory { get; set; } = null;
     }
 }

--- a/src/Geta.Optimizely.Sitemaps/Configuration/SitemapOptions.cs
+++ b/src/Geta.Optimizely.Sitemaps/Configuration/SitemapOptions.cs
@@ -1,5 +1,6 @@
-using System;
+using System.Linq;
 using Geta.Optimizely.Sitemaps.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Geta.Optimizely.Sitemaps.Configuration
 {
@@ -8,5 +9,14 @@ namespace Geta.Optimizely.Sitemaps.Configuration
         public bool EnableRealtimeSitemap { get; set; } = false;
         public bool EnableRealtimeCaching { get; set; } = true;
         public bool EnableLanguageDropDownInAdmin { get; set; } = false;
+
+        public void SetAugmenterService<T>(IServiceCollection services) where T : class, IUriAugmenterService
+        {
+            var augmenterService = services.First(sd => sd.ServiceType == typeof(IUriAugmenterService));
+            // Remove the existing service in order to replace it.
+            services.Remove(augmenterService);
+            
+            services.AddSingleton<IUriAugmenterService, T>();
+        }
     }
 }

--- a/src/Geta.Optimizely.Sitemaps/ServiceCollectionExtensions.cs
+++ b/src/Geta.Optimizely.Sitemaps/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using EPiServer.Authorization;
 using EPiServer.Shell.Modules;
@@ -7,6 +7,7 @@ using Geta.Optimizely.Sitemaps.Configuration;
 using Geta.Optimizely.Sitemaps.Entities;
 using Geta.Optimizely.Sitemaps.Models;
 using Geta.Optimizely.Sitemaps.Repositories;
+using Geta.Optimizely.Sitemaps.Services;
 using Geta.Optimizely.Sitemaps.Utils;
 using Geta.Optimizely.Sitemaps.XML;
 using Microsoft.AspNetCore.Authorization;
@@ -42,6 +43,7 @@ namespace Geta.Optimizely.Sitemaps
             services.AddSingleton<ISitemapLoader, SitemapLoader>();
             services.AddSingleton<ISitemapRepository, SitemapRepository>();
             services.AddSingleton<IContentFilter, ContentFilter>();
+            services.AddSingleton<IUriAugmenterService, NullUriAugmenterService>();
             services.AddTransient<IMobileSitemapXmlGenerator, MobileSitemapXmlGenerator>();
             services.AddTransient<IStandardSitemapXmlGenerator, StandardSitemapXmlGenerator>();
             services.AddTransient(typeof(IMapper<SitemapViewModel, SitemapData>), typeof(SitemapViewModel.MapperToEntity));

--- a/src/Geta.Optimizely.Sitemaps/ServiceCollectionExtensions.cs
+++ b/src/Geta.Optimizely.Sitemaps/ServiceCollectionExtensions.cs
@@ -57,13 +57,7 @@ namespace Geta.Optimizely.Sitemaps
             // Emulated - https://github.com/Geta/geta-optimizely-productfeed/blob/master/src/Geta.Optimizely.ProductFeed/ServiceCollectionExtensions.cs
             var options = new SitemapOptions();
             setupAction(options);
-            if (options.UriAugmenterService != null)
-            {
-                services.AddSingleton(typeof(IUriAugmenterService), options.UriAugmenterService);
-            } else
-            {
-                services.AddSingleton<IUriAugmenterService, DefaultUriAugmenterService>();
-            }
+            services.AddSingleton(typeof(IUriAugmenterService), options.UriAugmenterService);
 
             services.AddAuthorization(options =>
             {

--- a/src/Geta.Optimizely.Sitemaps/ServiceCollectionExtensions.cs
+++ b/src/Geta.Optimizely.Sitemaps/ServiceCollectionExtensions.cs
@@ -43,7 +43,6 @@ namespace Geta.Optimizely.Sitemaps
             services.AddSingleton<ISitemapLoader, SitemapLoader>();
             services.AddSingleton<ISitemapRepository, SitemapRepository>();
             services.AddSingleton<IContentFilter, ContentFilter>();
-            services.AddSingleton<IUriAugmenterService, DefaultUriAugmenterService>();
             services.AddTransient<IMobileSitemapXmlGenerator, MobileSitemapXmlGenerator>();
             services.AddTransient<IStandardSitemapXmlGenerator, StandardSitemapXmlGenerator>();
             services.AddTransient(typeof(IMapper<SitemapViewModel, SitemapData>), typeof(SitemapViewModel.MapperToEntity));
@@ -54,6 +53,17 @@ namespace Geta.Optimizely.Sitemaps
                 setupAction(options);
                 configuration.GetSection("Geta:Sitemaps").Bind(options);
             });
+
+            // Emulated - https://github.com/Geta/geta-optimizely-productfeed/blob/master/src/Geta.Optimizely.ProductFeed/ServiceCollectionExtensions.cs
+            var options = new SitemapOptions();
+            setupAction(options);
+            if (options.UriAugmenterService != null)
+            {
+                services.AddSingleton(typeof(IUriAugmenterService), options.UriAugmenterService);
+            } else
+            {
+                services.AddSingleton<IUriAugmenterService, DefaultUriAugmenterService>();
+            }
 
             services.AddAuthorization(options =>
             {

--- a/src/Geta.Optimizely.Sitemaps/ServiceCollectionExtensions.cs
+++ b/src/Geta.Optimizely.Sitemaps/ServiceCollectionExtensions.cs
@@ -54,7 +54,6 @@ namespace Geta.Optimizely.Sitemaps
                 configuration.GetSection("Geta:Sitemaps").Bind(options);
             });
 
-            // Emulated - https://github.com/Geta/geta-optimizely-productfeed/blob/master/src/Geta.Optimizely.ProductFeed/ServiceCollectionExtensions.cs
             var options = new SitemapOptions();
             setupAction(options);
             services.AddSingleton(typeof(IUriAugmenterService), options.UriAugmenterService);

--- a/src/Geta.Optimizely.Sitemaps/ServiceCollectionExtensions.cs
+++ b/src/Geta.Optimizely.Sitemaps/ServiceCollectionExtensions.cs
@@ -43,7 +43,6 @@ namespace Geta.Optimizely.Sitemaps
             services.AddSingleton<ISitemapLoader, SitemapLoader>();
             services.AddSingleton<ISitemapRepository, SitemapRepository>();
             services.AddSingleton<IContentFilter, ContentFilter>();
-            services.AddSingleton<IUriAugmenterService, NullUriAugmenterService>();
             services.AddTransient<IMobileSitemapXmlGenerator, MobileSitemapXmlGenerator>();
             services.AddTransient<IStandardSitemapXmlGenerator, StandardSitemapXmlGenerator>();
             services.AddTransient(typeof(IMapper<SitemapViewModel, SitemapData>), typeof(SitemapViewModel.MapperToEntity));
@@ -53,6 +52,14 @@ namespace Geta.Optimizely.Sitemaps
             {
                 setupAction(options);
                 configuration.GetSection("Geta:Sitemaps").Bind(options);
+                
+                if (options.UriAugmenterServiceImplementationFactory != null)
+                {
+                    services.AddSingleton(typeof(IUriAugmenterService), options.UriAugmenterServiceImplementationFactory);
+                } else
+                {
+                    services.AddSingleton<IUriAugmenterService, DefaultUriAugmenterService>();
+                }
             });
 
             services.AddAuthorization(options =>

--- a/src/Geta.Optimizely.Sitemaps/Services/DefaultUriAugmenterService.cs
+++ b/src/Geta.Optimizely.Sitemaps/Services/DefaultUriAugmenterService.cs
@@ -6,9 +6,9 @@ using EPiServer.ServiceLocation;
 namespace Geta.Optimizely.Sitemaps.Services
 {
     [ServiceConfiguration(typeof(IUriAugmenterService))]
-    public class NullUriAugmenterService : IUriAugmenterService
+    public class DefaultUriAugmenterService : IUriAugmenterService
     {
-        public IEnumerable<Uri> AugmentUri(IContent content, CurrentLanguageContent languageContentInfo, Uri fullUri)
+        public IEnumerable<Uri> GetAugmentUri(IContent content, CurrentLanguageContent languageContentInfo, Uri fullUri)
         {
             return new Uri[] { fullUri };
         }

--- a/src/Geta.Optimizely.Sitemaps/Services/DefaultUriAugmenterService.cs
+++ b/src/Geta.Optimizely.Sitemaps/Services/DefaultUriAugmenterService.cs
@@ -9,7 +9,7 @@ namespace Geta.Optimizely.Sitemaps.Services
     {
         public IEnumerable<Uri> GetAugmentUri(IContent content, CurrentLanguageContent languageContentInfo, Uri fullUri)
         {
-            return new Uri[] { fullUri };
+            yield return fullUri;
         }
     }
 }

--- a/src/Geta.Optimizely.Sitemaps/Services/DefaultUriAugmenterService.cs
+++ b/src/Geta.Optimizely.Sitemaps/Services/DefaultUriAugmenterService.cs
@@ -7,7 +7,7 @@ namespace Geta.Optimizely.Sitemaps.Services
 {
     public class DefaultUriAugmenterService : IUriAugmenterService
     {
-        public IEnumerable<Uri> GetAugmentUri(IContent content, CurrentLanguageContent languageContentInfo, Uri fullUri)
+        public IEnumerable<Uri> GetAugmentUris(IContent content, CurrentLanguageContent languageContentInfo, Uri fullUri)
         {
             yield return fullUri;
         }

--- a/src/Geta.Optimizely.Sitemaps/Services/DefaultUriAugmenterService.cs
+++ b/src/Geta.Optimizely.Sitemaps/Services/DefaultUriAugmenterService.cs
@@ -5,7 +5,6 @@ using EPiServer.ServiceLocation;
 
 namespace Geta.Optimizely.Sitemaps.Services
 {
-    [ServiceConfiguration(typeof(IUriAugmenterService))]
     public class DefaultUriAugmenterService : IUriAugmenterService
     {
         public IEnumerable<Uri> GetAugmentUri(IContent content, CurrentLanguageContent languageContentInfo, Uri fullUri)

--- a/src/Geta.Optimizely.Sitemaps/Services/IUriAugmenterService.cs
+++ b/src/Geta.Optimizely.Sitemaps/Services/IUriAugmenterService.cs
@@ -13,6 +13,6 @@ namespace Geta.Optimizely.Sitemaps.Services
         /// <param name="languageContentInfo">Language for URI</param>
         /// <param name="originUri">Origin URI to be included in sitemap</param>
         /// <returns>Must include origin to be included in sitemap</returns>
-        IEnumerable<Uri> GetAugmentUri(IContent content, CurrentLanguageContent languageContentInfo, Uri originUri);
+        IEnumerable<Uri> GetAugmentUris(IContent content, CurrentLanguageContent languageContentInfo, Uri originUri);
     }
 }

--- a/src/Geta.Optimizely.Sitemaps/Services/IUriAugmenterService.cs
+++ b/src/Geta.Optimizely.Sitemaps/Services/IUriAugmenterService.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using EPiServer.Core;
+
+namespace Geta.Optimizely.Sitemaps.Services
+{
+    public interface IUriAugmenterService
+    {
+        /// <summary>
+        /// Allows sitemap implementer an easy facility to take a simple url and expand it in a number of ways, includig parameterizing it with QueryStrings.
+        /// </summary>
+        /// <param name="content">Original content of page url being created.</param>
+        /// <param name="languageContentInfo">Language for Uri</param>
+        /// <param name="originUri">Origin uri to be included in sitemap.</param>
+        /// <returns>Must include origin to be included in sitemap.</returns>
+        IEnumerable<Uri> AugmentUri(IContent content, CurrentLanguageContent languageContentInfo, Uri originUri);
+    }
+}

--- a/src/Geta.Optimizely.Sitemaps/Services/IUriAugmenterService.cs
+++ b/src/Geta.Optimizely.Sitemaps/Services/IUriAugmenterService.cs
@@ -9,10 +9,10 @@ namespace Geta.Optimizely.Sitemaps.Services
         /// <summary>
         /// Allows sitemap implementer an easy facility to take a simple url and expand it in a number of ways, includig parameterizing it with QueryStrings.
         /// </summary>
-        /// <param name="content">Original content of page url being created.</param>
-        /// <param name="languageContentInfo">Language for Uri</param>
-        /// <param name="originUri">Origin uri to be included in sitemap.</param>
-        /// <returns>Must include origin to be included in sitemap.</returns>
-        IEnumerable<Uri> AugmentUri(IContent content, CurrentLanguageContent languageContentInfo, Uri originUri);
+        /// <param name="content">Original content of page URL being created.</param>
+        /// <param name="languageContentInfo">Language for URI</param>
+        /// <param name="originUri">Origin URI to be included in sitemap</param>
+        /// <returns>Must include origin to be included in sitemap</returns>
+        IEnumerable<Uri> GetAugmentUri(IContent content, CurrentLanguageContent languageContentInfo, Uri originUri);
     }
 }

--- a/src/Geta.Optimizely.Sitemaps/Services/IUriAugmenterService.cs
+++ b/src/Geta.Optimizely.Sitemaps/Services/IUriAugmenterService.cs
@@ -9,7 +9,7 @@ namespace Geta.Optimizely.Sitemaps.Services
         /// <summary>
         /// Allows sitemap implementer an easy facility to take a simple url and expand it in a number of ways, includig parameterizing it with QueryStrings.
         /// </summary>
-        /// <param name="content">Original content of page URL being created.</param>
+        /// <param name="content">Original content of page URL being created</param>
         /// <param name="languageContentInfo">Language for URI</param>
         /// <param name="originUri">Origin URI to be included in sitemap</param>
         /// <returns>Must include origin to be included in sitemap</returns>

--- a/src/Geta.Optimizely.Sitemaps/Services/NullUriAugmenterService.cs
+++ b/src/Geta.Optimizely.Sitemaps/Services/NullUriAugmenterService.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using EPiServer.Core;
+using EPiServer.ServiceLocation;
+
+namespace Geta.Optimizely.Sitemaps.Services
+{
+    [ServiceConfiguration(typeof(IUriAugmenterService))]
+    public class NullUriAugmenterService : IUriAugmenterService
+    {
+        public IEnumerable<Uri> AugmentUri(IContent content, CurrentLanguageContent languageContentInfo, Uri fullUri)
+        {
+            return new Uri[] { fullUri };
+        }
+    }
+}

--- a/src/Geta.Optimizely.Sitemaps/XML/MobileSitemapXmlGenerator.cs
+++ b/src/Geta.Optimizely.Sitemaps/XML/MobileSitemapXmlGenerator.cs
@@ -9,6 +9,7 @@ using EPiServer.Framework.Cache;
 using EPiServer.Web;
 using EPiServer.Web.Routing;
 using Geta.Optimizely.Sitemaps.Repositories;
+using Geta.Optimizely.Sitemaps.Services;
 using Geta.Optimizely.Sitemaps.Utils;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -24,6 +25,7 @@ namespace Geta.Optimizely.Sitemaps.XML
             ISiteDefinitionRepository siteDefinitionRepository,
             ILanguageBranchRepository languageBranchRepository,
             IContentFilter contentFilter,
+            IUriAugmenterService uriAugmenterService,
             ISynchronizedObjectInstanceCache objectCache,
             IMemoryCache cache,
             ILogger<MobileSitemapXmlGenerator> logger)
@@ -34,6 +36,7 @@ namespace Geta.Optimizely.Sitemaps.XML
                 siteDefinitionRepository,
                 languageBranchRepository,
                 contentFilter,
+                uriAugmenterService,
                 objectCache,
                 cache,
                 logger)

--- a/src/Geta.Optimizely.Sitemaps/XML/SitemapXmlGenerator.cs
+++ b/src/Geta.Optimizely.Sitemaps/XML/SitemapXmlGenerator.cs
@@ -182,14 +182,12 @@ namespace Geta.Optimizely.Sitemaps.XML
             return GenerateXmlElements(descendants);
         }
 
-        protected virtual IEnumerable<XElement> GenerateXmlElements(List<ContentReference> pages)
+        protected virtual IEnumerable<XElement> GenerateXmlElements(IEnumerable<ContentReference> pages)
         {
             var sitemapXmlElements = new List<XElement>();
 
-            for (var p = 0; p < pages.Count; p++)
+            foreach (var contentReference in pages)
             {
-                var contentReference = pages[p];
-
                 if (StopGeneration)
                 {
                     return Enumerable.Empty<XElement>();
@@ -461,7 +459,7 @@ namespace Geta.Optimizely.Sitemaps.XML
 
             var contentUrl = new Uri(url);
 
-            foreach (var fullContentUrl in _uriAugmenterService.GetAugmentUri(content, languageContentInfo, contentUrl))
+            foreach (var fullContentUrl in _uriAugmenterService.GetAugmentUris(content, languageContentInfo, contentUrl))
             {
                 var fullUrl = fullContentUrl.ToString();
 

--- a/src/Geta.Optimizely.Sitemaps/XML/SitemapXmlGenerator.cs
+++ b/src/Geta.Optimizely.Sitemaps/XML/SitemapXmlGenerator.cs
@@ -454,7 +454,7 @@ namespace Geta.Optimizely.Sitemaps.XML
 
             var contentUrl = new Uri(url);
 
-            foreach (var fullContentUrl in _uriAugmenterService.AugmentUri(content, languageContentInfo, contentUrl))
+            foreach (var fullContentUrl in _uriAugmenterService.GetAugmentUri(content, languageContentInfo, contentUrl))
             {
                 var fullUrl = fullContentUrl.ToString();
 

--- a/src/Geta.Optimizely.Sitemaps/XML/SitemapXmlGenerator.cs
+++ b/src/Geta.Optimizely.Sitemaps/XML/SitemapXmlGenerator.cs
@@ -182,18 +182,25 @@ namespace Geta.Optimizely.Sitemaps.XML
             return GenerateXmlElements(descendants);
         }
 
-        protected virtual IEnumerable<XElement> GenerateXmlElements(IEnumerable<ContentReference> pages)
+        protected virtual IEnumerable<XElement> GenerateXmlElements(List<ContentReference> pages)
         {
             var sitemapXmlElements = new List<XElement>();
 
-            foreach (var contentReference in pages)
+            for (var p = 0; p < pages.Count; p++)
             {
+                var contentReference = pages[p];
+
                 if (StopGeneration)
                 {
                     return Enumerable.Empty<XElement>();
                 }
 
                 if (TryGet<IExcludeFromSitemap>(contentReference, out _))
+                {
+                    continue;
+                }
+
+                if (ContentReference.IsNullOrEmpty(contentReference))
                 {
                     continue;
                 }

--- a/src/Geta.Optimizely.Sitemaps/XML/SitemapXmlGenerator.cs
+++ b/src/Geta.Optimizely.Sitemaps/XML/SitemapXmlGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Geta Digital. All rights reserved.
+// Copyright (c) Geta Digital. All rights reserved.
 // Licensed under Apache-2.0. See the LICENSE file in the project root for more information
 
 using System;
@@ -19,6 +19,7 @@ using EPiServer.Web.Routing;
 using Geta.Optimizely.Sitemaps.Entities;
 using Geta.Optimizely.Sitemaps.Models;
 using Geta.Optimizely.Sitemaps.Repositories;
+using Geta.Optimizely.Sitemaps.Services;
 using Geta.Optimizely.Sitemaps.SpecializedProperties;
 using Geta.Optimizely.Sitemaps.Utils;
 using Microsoft.Extensions.Caching.Memory;
@@ -41,6 +42,7 @@ namespace Geta.Optimizely.Sitemaps.XML
         protected readonly ISiteDefinitionRepository SiteDefinitionRepository;
         protected readonly ILanguageBranchRepository LanguageBranchRepository;
         protected readonly IContentFilter ContentFilter;
+        private readonly IUriAugmenterService _uriAugmenterService;
         private readonly ISynchronizedObjectInstanceCache _objectCache;
         private readonly IMemoryCache _memoryCache;
         private readonly ILogger<SitemapXmlGenerator> _logger;
@@ -55,6 +57,8 @@ namespace Geta.Optimizely.Sitemaps.XML
 
         public bool IsDebugMode { get; set; }
 
+        private readonly Regex _dashRegex = new Regex("[-]+", RegexOptions.Compiled);
+
         protected SitemapXmlGenerator(
             ISitemapRepository sitemapRepository,
             IContentRepository contentRepository,
@@ -62,6 +66,7 @@ namespace Geta.Optimizely.Sitemaps.XML
             ISiteDefinitionRepository siteDefinitionRepository,
             ILanguageBranchRepository languageBranchRepository,
             IContentFilter contentFilter,
+            IUriAugmenterService uriAugmenterService,
             ISynchronizedObjectInstanceCache objectCache,
             IMemoryCache memoryCache,
             ILogger<SitemapXmlGenerator> logger)
@@ -74,6 +79,7 @@ namespace Geta.Optimizely.Sitemaps.XML
             EnabledLanguages = LanguageBranchRepository.ListEnabled();
             UrlSet = new HashSet<string>();
             ContentFilter = contentFilter;
+            _uriAugmenterService = uriAugmenterService;
             _objectCache = objectCache;
             _memoryCache = memoryCache;
             _logger = logger;
@@ -389,7 +395,7 @@ namespace Geta.Optimizely.Sitemaps.XML
             if (IsDebugMode)
             {
                 var language = contentData is ILocale localeContent ? localeContent.Language : CultureInfo.InvariantCulture;
-                var contentName = Regex.Replace(contentData.Name, "[-]+", "", RegexOptions.None);
+                var contentName = _dashRegex.Replace(contentData.Name, string.Empty);
 
                 element.AddFirst(
                     new XComment($"page ID: '{contentData.ContentLink.ID}', name: '{contentName}', language: '{language.Name}'"));
@@ -446,22 +452,27 @@ namespace Geta.Optimizely.Sitemaps.XML
 
             url = GetAbsoluteUrl(url);
 
-            var fullContentUrl = new Uri(url);
+            var contentUrl = new Uri(url);
 
-            if (UrlSet.Contains(fullContentUrl.ToString()) || UrlFilter.IsUrlFiltered(fullContentUrl.AbsolutePath, SitemapData))
+            foreach (var fullContentUrl in _uriAugmenterService.AugmentUri(content, languageContentInfo, contentUrl))
             {
-                return;
+                var fullUrl = fullContentUrl.ToString();
+
+                if (UrlSet.Contains(fullUrl) || UrlFilter.IsUrlFiltered(fullContentUrl.AbsolutePath, SitemapData))
+                {
+                    continue;
+                }
+
+                var contentElement = GenerateSiteElement(content, fullUrl);
+
+                if (contentElement == null)
+                {
+                    continue;
+                }
+
+                xmlElements.Add(contentElement);
+                UrlSet.Add(fullUrl);
             }
-
-            var contentElement = GenerateSiteElement(content, fullContentUrl.ToString());
-
-            if (contentElement == null)
-            {
-                return;
-            }
-
-            xmlElements.Add(contentElement);
-            UrlSet.Add(fullContentUrl.ToString());
         }
 
         protected virtual XElement CreateHrefLangElement(HrefLangData data)

--- a/src/Geta.Optimizely.Sitemaps/XML/StandardSitemapXmlGenerator.cs
+++ b/src/Geta.Optimizely.Sitemaps/XML/StandardSitemapXmlGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Geta Digital. All rights reserved.
+// Copyright (c) Geta Digital. All rights reserved.
 // Licensed under Apache-2.0. See the LICENSE file in the project root for more information
 
 using EPiServer;
@@ -7,6 +7,7 @@ using EPiServer.Framework.Cache;
 using EPiServer.Web;
 using EPiServer.Web.Routing;
 using Geta.Optimizely.Sitemaps.Repositories;
+using Geta.Optimizely.Sitemaps.Services;
 using Geta.Optimizely.Sitemaps.Utils;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -22,6 +23,7 @@ namespace Geta.Optimizely.Sitemaps.XML
             ISiteDefinitionRepository siteDefinitionRepository,
             ILanguageBranchRepository languageBranchRepository,
             IContentFilter contentFilter,
+            IUriAugmenterService uriAugmenterService,
             ISynchronizedObjectInstanceCache objectCache,
             IMemoryCache cache,
             ILogger<StandardSitemapXmlGenerator> logger)
@@ -32,6 +34,7 @@ namespace Geta.Optimizely.Sitemaps.XML
                 siteDefinitionRepository,
                 languageBranchRepository,
                 contentFilter,
+                uriAugmenterService,
                 objectCache,
                 cache,
                 logger)


### PR DESCRIPTION
Some of the pages are not as simple as standard pages that need to be added to the sitemap. The Url needs to be augmented in order to be correctly indexed by google as the page requires Url parameters in order to correctly display data.

The UriAugmenterService takes an IContent, CurrentLanguageContent and Uri and turns it into an IEnumerable<Uri> in order to take a single Uri and convert it into many possible Uris that are required to be indexed.

Additionally, this PR includes several files that were on disk (.gitignore, .md and nuget.config) into the solution for easy modification and fixes an uncompiled Regular Expression which will cause unnecessary excessive JIT compilation.