### PR TITLE
Default ContentFilter Fixes (0 entries fixes)

### DIFF
--- a/src/Geta.Optimizely.Sitemaps/Configuration/SiteArchitecture.cs
+++ b/src/Geta.Optimizely.Sitemaps/Configuration/SiteArchitecture.cs
@@ -1,0 +1,8 @@
+namespace Geta.Optimizely.Sitemaps.Configuration
+{
+    public enum SiteArchitecture
+    {
+        Mvc,
+        Headless
+    }
+}

--- a/src/Geta.Optimizely.Sitemaps/Configuration/SitemapOptions.cs
+++ b/src/Geta.Optimizely.Sitemaps/Configuration/SitemapOptions.cs
@@ -9,6 +9,18 @@ namespace Geta.Optimizely.Sitemaps.Configuration
         public bool EnableRealtimeCaching { get; set; } = true;
         public bool EnableLanguageDropDownInAdmin { get; set; } = false;
 
+        /// <summary>
+        /// The default is Mvc, this runs a check in the default content filter to ensure there's a page for every piece of content
+        /// Set this to headless if you are running a headless site to skip this check
+        /// </summary>
+        public SiteArchitecture SiteArchitecture { get; set; } = SiteArchitecture.Mvc;
+
+        /// <summary>
+        /// Enabled by default, this will, when using the default Content Filter, assume that content that can't be cast to IVersionable is unpublished
+        /// Consider disabling if you are finding that the default content filter is not generating content you're expecting for your sitemap
+        /// </summary>
+        public bool IsStrictPublishCheckingEnabled { get; set; } = true;
+
         public Type UriAugmenterService { get; set; } = typeof(DefaultUriAugmenterService);
 
         public void SetAugmenterService<T>() where T : class, IUriAugmenterService

--- a/src/Geta.Optimizely.Sitemaps/Utils/ContentFilter.cs
+++ b/src/Geta.Optimizely.Sitemaps/Utils/ContentFilter.cs
@@ -1,14 +1,17 @@
-﻿// Copyright (c) Geta Digital. All rights reserved.
+// Copyright (c) Geta Digital. All rights reserved.
 // Licensed under Apache-2.0. See the LICENSE file in the project root for more information
 
 using System;
+using AspNetCore;
 using EPiServer.Core;
 using EPiServer.Framework.Web;
 using EPiServer.Security;
 using EPiServer.Web;
+using Geta.Optimizely.Sitemaps.Configuration;
 using Geta.Optimizely.Sitemaps.Entities;
 using Geta.Optimizely.Sitemaps.SpecializedProperties;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Geta.Optimizely.Sitemaps.Utils
 {
@@ -16,11 +19,13 @@ namespace Geta.Optimizely.Sitemaps.Utils
     {
         private readonly TemplateResolver _templateResolver;
         private readonly ILogger<ContentFilter> _logger;
+        private readonly SitemapOptions _sitemapOptions;
 
-        public ContentFilter(TemplateResolver templateResolver, ILogger<ContentFilter> logger)
+        public ContentFilter(TemplateResolver templateResolver, ILogger<ContentFilter> logger, IOptions<SitemapOptions> sitemapOptions)
         {
             _templateResolver = templateResolver;
             _logger = logger;
+            _sitemapOptions = sitemapOptions.Value;
         }
 
         public virtual bool ShouldExcludeContent(IContent content)
@@ -41,7 +46,7 @@ namespace Geta.Optimizely.Sitemaps.Utils
             }
 
 
-            if (!IsPublished(content))
+            if (!IsPublished(content, _sitemapOptions.IsStrictPublishCheckingEnabled))
             {
                 return true;
             }
@@ -51,9 +56,12 @@ namespace Geta.Optimizely.Sitemaps.Utils
                 return true;
             }
 
-            if (!IsVisibleOnSite(content))
+            if (_sitemapOptions.SiteArchitecture == SiteArchitecture.Mvc)
             {
-                return true;
+                if (!IsVisibleOnSite(content))
+                {
+                    return true;
+                }
             }
 
             if (content.ContentLink.CompareToIgnoreWorkID(ContentReference.WasteBasket))
@@ -76,8 +84,7 @@ namespace Geta.Optimizely.Sitemaps.Utils
             return false;
         }
 
-        public virtual bool ShouldExcludeContent(
-            CurrentLanguageContent languageContentInfo, SiteDefinition siteSettings, SitemapData sitemapData)
+        public virtual bool ShouldExcludeContent(CurrentLanguageContent languageContentInfo, SiteDefinition siteSettings, SitemapData sitemapData)
         {
             return ShouldExcludeContent(languageContentInfo.Content);
         }
@@ -141,7 +148,7 @@ namespace Geta.Optimizely.Sitemaps.Utils
             return false;
         }
 
-        private static bool IsPublished(IContent content)
+        private static bool IsPublished(IContent content, bool isStrictPublishCheckingEnabled)
         {
             if (content is IVersionable versionableContent)
             {
@@ -164,7 +171,7 @@ namespace Geta.Optimizely.Sitemaps.Utils
                 return true;
             }
 
-            return false;
+            return !isStrictPublishCheckingEnabled;
         }
     }
 }


### PR DESCRIPTION
There's been a few issues picked up regarding this package where people are posting "Scheduled job ran but shows 0 entries". 
My team and I ran into the same thing and then I realized why when I looked at the default ContentFilter.

Here's some improvements to the default ContentFilter that hopefully makes sense. 

**1)** The first thing I picked up is, we ran into a case where much of our content could not be cast to `IVersionable` and the logic here assumes that content is unpublished if it can't be cast to `IVersionable` which is a dangerous assumption but also tricky, as we can't assume the opposite either. 

I added an option in SitemapOptions so the consuming party can decide whether this strict check is necessary (If they decide to use the default ContentFilter)

**2)** The 2nd thing I picked up is that the `IsVisibleOnSite` check prohibits this package from working in any sort of headless site. In addition to the previous prop, I also added a `SiteArchitecture` enum which defaults to Mvc, but can be set to headless. This just skips the `IsVisibleOnSite` check if the site architecture is set to headless by the consuming party of this package.

I hope this makes sense, I'm open to suggestions / adjustments.