### PR TITLE
Update GitHub Actions cache to use actions/cache@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           submodules: recursive
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~\sonar\cache
           key: ${{ runner.os }}-sonar
@@ -30,7 +30,7 @@ jobs:
 
       - name: Cache SonarCloud scanner
         id: cache-sonar-scanner
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .\.sonar\scanner
           key: ${{ runner.os }}-sonar-scanner


### PR DESCRIPTION
Upgraded from actions/cache@v1 to actions/cache@v4 in the build workflow for caching SonarCloud packages and scanner. This ensures compatibility with the latest features and improvements in the caching action. No changes to caching behavior or paths were made.