### PR TITLE
SiteSettings is null when there are no host definitions. Fix null ref…

### DIFF
--- a/src/Geta.Optimizely.Sitemaps/XML/SitemapXmlGenerator.cs
+++ b/src/Geta.Optimizely.Sitemaps/XML/SitemapXmlGenerator.cs
@@ -557,8 +557,9 @@ namespace Geta.Optimizely.Sitemaps.XML
             var siteUrl = new Uri(SitemapData.SiteUrl);
             var sitemapHost = siteUrl.Authority;
 
-            return SiteSettings?.Hosts?.FirstOrDefault(x => x.Name.Equals(sitemapHost, StringComparison.InvariantCultureIgnoreCase))
-                   ?? SiteSettings?.Hosts?.FirstOrDefault(x => x.Name.Equals(SiteDefinition.WildcardHostName));
+            var hosts = SiteSettings?.Hosts;
+            return hosts?.FirstOrDefault(x => x.Name.Equals(sitemapHost, StringComparison.InvariantCultureIgnoreCase)) ??
+                   hosts?.FirstOrDefault(x => x.Name.Equals(SiteDefinition.WildcardHostName));
         }
 
         protected bool ExcludeContentLanguageFromSitemap(CultureInfo language)

--- a/src/Geta.Optimizely.Sitemaps/XML/SitemapXmlGenerator.cs
+++ b/src/Geta.Optimizely.Sitemaps/XML/SitemapXmlGenerator.cs
@@ -557,8 +557,8 @@ namespace Geta.Optimizely.Sitemaps.XML
             var siteUrl = new Uri(SitemapData.SiteUrl);
             var sitemapHost = siteUrl.Authority;
 
-            return SiteSettings.Hosts.FirstOrDefault(x => x.Name.Equals(sitemapHost, StringComparison.InvariantCultureIgnoreCase))
-                   ?? SiteSettings.Hosts.FirstOrDefault(x => x.Name.Equals(SiteDefinition.WildcardHostName));
+            return SiteSettings?.Hosts?.FirstOrDefault(x => x.Name.Equals(sitemapHost, StringComparison.InvariantCultureIgnoreCase))
+                   ?? SiteSettings?.Hosts?.FirstOrDefault(x => x.Name.Equals(SiteDefinition.WildcardHostName));
         }
 
         protected bool ExcludeContentLanguageFromSitemap(CultureInfo language)


### PR DESCRIPTION
…erence exception in sitemap host resolution. In case of unresolved host, an empty sitemap will be generated as no site definition matches one set in sitemap definition.

Added null checks for SiteSettings and Hosts to prevent potential null reference exceptions when resolving the sitemap host. This ensures more robust handling of scenarios where SiteSettings or Hosts might be null.